### PR TITLE
Add Python dependency list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+flask
+flask-cors
+websockets
+RPi.GPIO
+smbus
+psutil
+adafruit-blinka
+adafruit-circuitpython-motor
+adafruit-circuitpython-pca9685


### PR DESCRIPTION
## Summary
- Provide a requirements.txt listing the Python dependencies for the server and web server components.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6898ca4d4fa4832abaa3a7badac30abb